### PR TITLE
Refactor Neo4j ingestion through configurable pipelines

### DIFF
--- a/src/codebase_rag/config/settings.py
+++ b/src/codebase_rag/config/settings.py
@@ -7,7 +7,7 @@ Settings can be configured via environment variables or .env file.
 
 from pydantic_settings import BaseSettings
 from pydantic import Field
-from typing import Optional, Literal
+from typing import Optional, Literal, Dict, Any
 
 
 class Settings(BaseSettings):
@@ -99,6 +99,10 @@ class Settings(BaseSettings):
     # Document Processing Settings
     max_document_size: int = Field(default=10 * 1024 * 1024, description="Maximum document size in bytes (10MB)")
     max_payload_size: int = Field(default=50 * 1024 * 1024, description="Maximum task payload size for storage (50MB)")
+    ingestion_pipelines: Dict[str, Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Optional ingestion pipeline overrides",
+    )
 
     # API Settings
     cors_origins: list = Field(default=["*"], description="CORS allowed origins")

--- a/src/codebase_rag/services/knowledge/neo4j_knowledge_service.py
+++ b/src/codebase_rag/services/knowledge/neo4j_knowledge_service.py
@@ -316,8 +316,10 @@ class Neo4jKnowledgeService:
         timeout: Optional[int] = None,
     ) -> Dict[str, Any]:
         if pipeline_name not in self._pipeline_bundles:
-            raise ValueError(f"Pipeline '{pipeline_name}' is not configured")
-
+            available_pipelines = ", ".join(self._pipeline_bundles.keys())
+            raise ValueError(
+                f"Pipeline '{pipeline_name}' is not configured. Available pipelines: {available_pipelines}"
+            )
         bundle = self._pipeline_bundles[pipeline_name]
         connector = bundle.instantiate_connector(**connector_overrides)
 

--- a/src/codebase_rag/services/knowledge/pipeline_components.py
+++ b/src/codebase_rag/services/knowledge/pipeline_components.py
@@ -1,0 +1,253 @@
+"""Reusable ingestion pipeline components for the Neo4j knowledge service."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Type
+
+from llama_index.core import Document
+from llama_index.core.ingestion import IngestionPipeline
+from llama_index.core.schema import BaseNode, TransformComponent
+
+from codebase_rag.config import settings
+
+try:  # pragma: no cover - optional dependency surface differs by version
+    from llama_index.core.ingestion import BaseConnector, BaseWriter
+except ImportError:  # pragma: no cover
+    from typing import Protocol
+
+    class BaseConnector(Protocol):  # type: ignore[misc]
+        """Minimal connector protocol used for runtime type checking."""
+
+        def load_data(self) -> Sequence[Document]:
+            ...
+
+        async def aload_data(self) -> Sequence[Document]:
+            ...
+
+    class BaseWriter(Protocol):  # type: ignore[misc]
+        """Minimal writer protocol used for runtime type checking."""
+
+        def write(self, nodes: Sequence[BaseNode]) -> None:
+            ...
+
+        async def awrite(self, nodes: Sequence[BaseNode]) -> None:
+            ...
+
+
+class BaseTransformation(TransformComponent):
+    """Alias for TransformComponent for readability."""
+
+    # TransformComponent already implements __call__/acall
+
+
+class ManualDocumentConnector(BaseConnector):
+    """Connector that materialises a single document from raw text input."""
+
+    def __init__(
+        self,
+        content: str,
+        *,
+        title: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._content = content
+        self._title = title or "Untitled"
+        self._metadata = metadata or {}
+
+    def _build_document(self) -> Document:
+        base_metadata = {
+            "title": self._title,
+            "source": self._metadata.get("source", "manual_input"),
+            "timestamp": self._metadata.get("timestamp", time.time()),
+        }
+        merged_metadata = {**base_metadata, **self._metadata}
+        return Document(text=self._content, metadata=merged_metadata)
+
+    def load_data(self) -> Sequence[Document]:
+        return [self._build_document()]
+
+    async def aload_data(self) -> Sequence[Document]:
+        return self.load_data()
+
+
+class SimpleFileConnector(BaseConnector):
+    """Connector that loads a single file via SimpleDirectoryReader."""
+
+    def __init__(self, file_path: str | Path, **reader_kwargs: Any) -> None:
+        self._file_path = Path(file_path)
+        self._reader_kwargs = reader_kwargs
+
+    def load_data(self) -> Sequence[Document]:
+        from llama_index.core import SimpleDirectoryReader
+
+        reader = SimpleDirectoryReader(
+            input_files=[str(self._file_path)],
+            **self._reader_kwargs,
+        )
+        return reader.load_data()
+
+    async def aload_data(self) -> Sequence[Document]:
+        return await asyncio.to_thread(self.load_data)
+
+
+class SimpleDirectoryConnector(BaseConnector):
+    """Connector that loads all supported files from a directory."""
+
+    def __init__(
+        self,
+        directory_path: str | Path,
+        *,
+        recursive: bool = True,
+        file_extensions: Optional[Sequence[str]] = None,
+        reader_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._directory_path = Path(directory_path)
+        self._recursive = recursive
+        self._file_extensions = list(file_extensions or [])
+        self._reader_kwargs = reader_kwargs or {}
+
+    def load_data(self) -> Sequence[Document]:
+        from llama_index.core import SimpleDirectoryReader
+
+        file_extractor = None
+        if self._file_extensions:
+            file_extractor = {ext: None for ext in self._file_extensions}
+
+        reader = SimpleDirectoryReader(
+            input_dir=str(self._directory_path),
+            recursive=self._recursive,
+            file_extractor=file_extractor,
+            **self._reader_kwargs,
+        )
+        return reader.load_data()
+
+    async def aload_data(self) -> Sequence[Document]:
+        return await asyncio.to_thread(self.load_data)
+
+
+class MetadataEnrichmentTransformation(BaseTransformation):
+    """Inject static metadata into every processed node."""
+
+    def __init__(self, metadata: Optional[Dict[str, Any]] = None) -> None:
+        self._metadata = metadata or {}
+
+    def __call__(self, nodes: Sequence[BaseNode], **kwargs: Any) -> Sequence[BaseNode]:
+        for node in nodes:
+            node.metadata.update(self._metadata)
+        return nodes
+
+
+class Neo4jKnowledgeGraphWriter(BaseWriter):
+    """Writer that persists nodes through the KnowledgeGraphIndex."""
+
+    def __init__(self, knowledge_index, graph_store) -> None:
+        self._knowledge_index = knowledge_index
+        self._graph_store = graph_store
+
+    def write(self, nodes: Sequence[BaseNode]) -> None:
+        if not nodes:
+            return
+        self._knowledge_index.insert_nodes(nodes)
+
+    async def awrite(self, nodes: Sequence[BaseNode]) -> None:
+        if not nodes:
+            return
+        await asyncio.to_thread(self._knowledge_index.insert_nodes, nodes)
+
+
+@dataclass
+class PipelineBundle:
+    """Container for an ingestion pipeline and its runtime dependencies."""
+
+    name: str
+    connector_cls: Type[BaseConnector]
+    connector_kwargs: Dict[str, Any]
+    pipeline: IngestionPipeline
+    writer: BaseWriter
+
+    def instantiate_connector(self, **overrides: Any) -> BaseConnector:
+        params = {**self.connector_kwargs, **overrides}
+        return self.connector_cls(**params)
+
+
+def import_from_string(dotted_path: str) -> Any:
+    """Import a class from a dotted module path."""
+
+    module_path, _, attribute = dotted_path.rpartition(".")
+    if not module_path:
+        raise ImportError(f"Invalid class path: {dotted_path}")
+    module = import_module(module_path)
+    try:
+        return getattr(module, attribute)
+    except AttributeError as exc:  # pragma: no cover - invalid config
+        raise ImportError(f"Module '{module_path}' has no attribute '{attribute}'") from exc
+
+
+def build_pipeline_bundle(
+    name: str,
+    *,
+    knowledge_index,
+    graph_store,
+    configuration: Dict[str, Any],
+) -> PipelineBundle:
+    """Construct a PipelineBundle from configuration metadata."""
+
+    connector_cfg = configuration.get("connector", {})
+    connector_cls = import_from_string(connector_cfg.get("class_path", ""))
+    connector_kwargs = connector_cfg.get("kwargs", {})
+
+    transformations: List[TransformComponent] = []
+    for transform_cfg in configuration.get("transformations", []):
+        transform_cls = import_from_string(transform_cfg["class_path"])
+        kwargs = transform_cfg.get("kwargs", {})
+        transformations.append(transform_cls(**kwargs))
+
+    if not transformations:
+        from llama_index.core.node_parser import SimpleNodeParser
+
+        transformations.append(
+            SimpleNodeParser.from_defaults(
+                chunk_size=settings.chunk_size,
+                chunk_overlap=settings.chunk_overlap,
+            )
+        )
+
+    writer_cfg = configuration.get("writer", {})
+    writer_cls = import_from_string(writer_cfg.get("class_path", ""))
+    writer_kwargs = writer_cfg.get("kwargs", {})
+    writer = writer_cls(knowledge_index=knowledge_index, graph_store=graph_store, **writer_kwargs)
+
+    pipeline = IngestionPipeline(transformations=transformations)
+    return PipelineBundle(
+        name=name,
+        connector_cls=connector_cls,
+        connector_kwargs=connector_kwargs,
+        pipeline=pipeline,
+        writer=writer,
+    )
+
+
+def merge_pipeline_configs(
+    default_config: Dict[str, Dict[str, Any]],
+    override_config: Optional[Dict[str, Dict[str, Any]]],
+) -> Dict[str, Dict[str, Any]]:
+    """Merge user supplied pipeline configuration with defaults."""
+
+    merged = {**default_config}
+    if not override_config:
+        return merged
+
+    for key, value in override_config.items():
+        if key in merged:
+            combined = dict(merged[key])
+            combined.update(value)
+            merged[key] = combined
+        else:
+            merged[key] = value
+    return merged
+

--- a/src/codebase_rag/services/knowledge/pipeline_components.py
+++ b/src/codebase_rag/services/knowledge/pipeline_components.py
@@ -253,7 +253,7 @@ def merge_pipeline_configs(
             return merged_dict
         if isinstance(override, dict):
             return copy.deepcopy(override)
-        return override
+        return copy.deepcopy(override)
 
     merged = copy.deepcopy(default_config)
     if not override_config:

--- a/src/codebase_rag/services/knowledge/pipeline_components.py
+++ b/src/codebase_rag/services/knowledge/pipeline_components.py
@@ -181,7 +181,7 @@ def import_from_string(dotted_path: str) -> Any:
 
     module_path, _, attribute = dotted_path.rpartition(".")
     if not module_path:
-        raise ImportError(f"Invalid class path: {dotted_path}")
+        raise ImportError(f"Invalid class path (must contain at least one dot): {dotted_path}")
     module = import_module(module_path)
     try:
         return getattr(module, attribute)

--- a/tests/services/test_pipeline_components.py
+++ b/tests/services/test_pipeline_components.py
@@ -1,0 +1,103 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+try:
+    spec = importlib.util.spec_from_file_location(
+        "codebase_rag.services.knowledge.pipeline_components",
+        Path("src/codebase_rag/services/knowledge/pipeline_components.py"),
+    )
+    pipeline_components = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(pipeline_components)
+except ImportError:  # pragma: no cover - dependency mismatch
+    pipeline_components = None
+    build_pipeline_bundle = merge_pipeline_configs = None
+else:
+    build_pipeline_bundle = pipeline_components.build_pipeline_bundle
+    merge_pipeline_configs = pipeline_components.merge_pipeline_configs
+
+pytestmark = pytest.mark.skipif(
+    pipeline_components is None, reason="llama_index could not be imported"
+)
+
+
+class DummyKnowledgeIndex:
+    def __init__(self) -> None:
+        self.inserted_nodes = []
+
+    def insert_nodes(self, nodes):
+        self.inserted_nodes.extend(nodes)
+
+
+class DummyGraphStore:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_build_pipeline_bundle_executes_pipeline():
+    config: Dict[str, Dict] = {
+        "connector": {
+            "class_path": "codebase_rag.services.knowledge.pipeline_components.ManualDocumentConnector",
+            "kwargs": {"metadata": {"source": "test"}},
+        },
+        "transformations": [
+            {
+                "class_path": "llama_index.core.node_parser.SimpleNodeParser",
+                "kwargs": {"chunk_size": 64, "chunk_overlap": 0},
+            },
+        ],
+        "writer": {
+            "class_path": "codebase_rag.services.knowledge.pipeline_components.Neo4jKnowledgeGraphWriter",
+        },
+    }
+
+    knowledge_index = DummyKnowledgeIndex()
+    bundle = build_pipeline_bundle(
+        "test",
+        knowledge_index=knowledge_index,
+        graph_store=DummyGraphStore(),
+        configuration=config,
+    )
+
+    connector = bundle.instantiate_connector(content="hello world", title="Test")
+    documents = await connector.aload_data()
+    assert len(documents) == 1
+
+    nodes = await asyncio.to_thread(
+        bundle.pipeline.run,
+        False,
+        documents,
+    )
+    assert nodes, "Pipeline should produce nodes"
+
+    bundle.writer.write(nodes)
+    assert knowledge_index.inserted_nodes, "Writer should forward nodes to knowledge index"
+
+
+def test_merge_pipeline_configs_allows_override():
+    default = {
+        "file": {
+            "connector": {"class_path": "default.Connector"},
+            "transformations": [],
+            "writer": {"class_path": "default.Writer"},
+        }
+    }
+    override = {
+        "file": {
+            "connector": {"kwargs": {"recursive": False}},
+        },
+        "custom": {
+            "connector": {"class_path": "custom.Connector"},
+            "transformations": [],
+            "writer": {"class_path": "custom.Writer"},
+        },
+    }
+
+    merged = merge_pipeline_configs(default, override)
+    assert merged["file"]["connector"]["class_path"] == "default.Connector"
+    assert merged["file"]["connector"]["kwargs"] == {"recursive": False}
+    assert "custom" in merged


### PR DESCRIPTION
## Summary
- refactor the Neo4j knowledge service to use reusable LlamaIndex ingestion pipelines with connectors, transformations, and writers
- add a configurable ingestion_pipelines setting plus default pipeline bundle helpers and reusable components
- document how to customize ingestion pipelines through configuration and cover the new helpers with unit tests (skipped when llama_index cannot be imported)

## Testing
- PYTHONPATH=src pytest tests/services/test_pipeline_components.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d664e2944832cbaeccb0a3dbf6f54)